### PR TITLE
Support wildcard cert in GCE load balancer

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -170,7 +170,7 @@ function deploy_cert {
 
     echo;
     echo "Deploying certificate for $DOMAIN from $KEYFILE and $FULLCHAINFILE"
-    canonicalname=$(sed 's:\.:-:g' <<< $DOMAIN)
+    canonicalname=$(sed -e 's:\.:-:g' -e 's:\*:wildcard:g' <<< $DOMAIN)
     certname=$canonicalname-$(date +%s)
     httpsproxyname=https-proxy-$canonicalname
 


### PR DESCRIPTION
Replace * with "wildcard" word to support GCE load balancer naming conventions when issuing a wildcard certificate.

If a cert is issued for *.example.com, the script originally tries to configure the following GCE proxy: 

> https-proxy-*-example-com

And this fails, because GCE doesn't allow the * character in the proxy name. I have replaced this * character to "wildcard".